### PR TITLE
gatsby-stack: Add configuration to resolve module path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "web-packages",
+  "version": "0.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "gatsby-plugin-module-resolver": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-module-resolver/-/gatsby-plugin-module-resolver-1.0.3.tgz",
+      "integrity": "sha512-MrE2JhDEiiZB6uLVJ0zpoZmHi36zkgGoNgBr9YQ4r6TUqayiNXU97NBhO87CRJQz8I4MaL6ZrOWjUdoHEXvndg=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
   "bugs": {
     "url": "https://github.com/devsisters/web-packages/issues"
   },
-  "homepage": "https://github.com/devsisters/web-packages#readme"
+  "homepage": "https://github.com/devsisters/web-packages#readme",
+  "dependencies": {
+    "gatsby-plugin-module-resolver": "^1.0.3"
+  }
 }

--- a/packages/gatsby-stack/src/index.ts
+++ b/packages/gatsby-stack/src/index.ts
@@ -13,6 +13,15 @@ export default function getStack(): GatsbyPlugin[] {
         },
       },
     },
+    {
+      resolve: 'gatsby-plugin-module-resolver',
+      options: {
+        root: './',
+        aliases: {
+          '~': '.',
+        },
+      },
+    },
   ];
   return plugins;
 }


### PR DESCRIPTION
Enabled importing module from CWD using `~/` as path prefix.

Projects may require additional configuration for TypeScript, in
`tsconfig.json`:

```json
{
    ...
    "compilerOptions": {
        ...
        "baseUrl": "./",
        "paths": {
            "~/*": ["*"]
        }
    }
}
```

Known Issue:
- Can't resolve path inside of Linaria CSS