### PR TITLE
Google Analytics 플러그인이 Tag Manager 없이 standalone으로 동작하도록 변경

### DIFF
--- a/packages/gatsby-plugin-autotrack/package-lock.json
+++ b/packages/gatsby-plugin-autotrack/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@devsisters/gatsby-plugin-autotrack",
-  "version": "2.0.0-beta",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/gatsby-plugin-autotrack/package-lock.json
+++ b/packages/gatsby-plugin-autotrack/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@devsisters/gatsby-plugin-autotrack",
-  "version": "1.4.0",
+  "version": "2.0.0-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/gatsby-plugin-autotrack/package.json
+++ b/packages/gatsby-plugin-autotrack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devsisters/gatsby-plugin-autotrack",
-  "version": "1.4.0",
+  "version": "2.0.0-beta",
   "description": "",
   "main": "index.js",
   "typings": "index.d.ts",
@@ -14,7 +14,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@devsisters/gatsby-plugin-google-analytics": "1.x",
+    "@devsisters/gatsby-plugin-google-analytics": "2.x",
     "@devsisters/gatsby-plugin-matomo": ">= 1.1.0 < 2"
   },
   "dependencies": {

--- a/packages/gatsby-plugin-autotrack/package.json
+++ b/packages/gatsby-plugin-autotrack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devsisters/gatsby-plugin-autotrack",
-  "version": "2.0.0-beta",
+  "version": "2.0.0",
   "description": "",
   "main": "index.js",
   "typings": "index.d.ts",
@@ -14,7 +14,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@devsisters/gatsby-plugin-google-analytics": "2.x",
+    "@devsisters/gatsby-plugin-google-analytics": ">=2.0",
     "@devsisters/gatsby-plugin-matomo": ">= 1.1.0 < 2"
   },
   "dependencies": {

--- a/packages/gatsby-plugin-autotrack/src/gatsby-browser.ts
+++ b/packages/gatsby-plugin-autotrack/src/gatsby-browser.ts
@@ -6,20 +6,15 @@ import { onhashchange } from '.';
 
 declare global {
   interface Window {
-    gtag: (...args: any[]) => void;
+    ga: (...args: any[]) => void;
     piwik: { trackEvent(category: string, action: string, name?: string, value?: string): void; };
   }
 }
 
 function trackEvent(category: string, action: string, name?: string) {
-  const { gtag, piwik } = window;
-  if (gtag) {
-    gtag('event', 'click', Object.assign({
-      event_category: category,
-      event_action: action,
-    }, name && {
-      event_label: name,
-    }));
+  const { ga, piwik } = window;
+  if (ga) {
+    ga('send', 'event', category, action, name);
   }
   if (piwik) {
     piwik.trackEvent(category, action, name);

--- a/packages/gatsby-plugin-google-analytics/package-lock.json
+++ b/packages/gatsby-plugin-google-analytics/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@devsisters/gatsby-plugin-google-analytics",
-  "version": "2.0.0-beta",
+  "version": "2.0.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/gatsby-plugin-google-analytics/package-lock.json
+++ b/packages/gatsby-plugin-google-analytics/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@devsisters/gatsby-plugin-google-analytics",
-  "version": "1.0.1",
+  "version": "2.0.0-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/gatsby-plugin-google-analytics/package-lock.json
+++ b/packages/gatsby-plugin-google-analytics/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@devsisters/gatsby-plugin-google-analytics",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/gatsby-plugin-google-analytics/package.json
+++ b/packages/gatsby-plugin-google-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devsisters/gatsby-plugin-google-analytics",
-  "version": "1.0.1",
+  "version": "2.0.0-beta",
   "description": "",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/packages/gatsby-plugin-google-analytics/package.json
+++ b/packages/gatsby-plugin-google-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devsisters/gatsby-plugin-google-analytics",
-  "version": "2.0.0-beta",
+  "version": "2.0.0-beta.0",
   "description": "",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/packages/gatsby-plugin-google-analytics/package.json
+++ b/packages/gatsby-plugin-google-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devsisters/gatsby-plugin-google-analytics",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0",
   "description": "",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/packages/gatsby-plugin-google-analytics/src/gatsby-browser.ts
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-browser.ts
@@ -1,11 +1,10 @@
 declare const window: {
-  gtag: (...args: any[]) => void;
+  ga: (...args: any[]) => void;
 };
 
 export const onRouteUpdate = ({ location }: { location: Location }, pluginOptions: any) => {
   const { trackingId } = pluginOptions;
   if (!trackingId) return;
-  window.gtag('config', trackingId, {
-    page_path: `${ location.pathname }${ location.search }${ location.hash }`,
-  });
+  const { pathname, search, hash } = location;
+  window.ga('send', 'pageview', pathname + search + hash);
 };

--- a/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.tsx
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.tsx
@@ -4,12 +4,14 @@ export const onRenderBody = ({ setHeadComponents }: any, pluginOptions: any) => 
   const { trackingId } = pluginOptions;
   if (!trackingId) return;
   setHeadComponents([
-    <script key="gtag" async src={`https://www.googletagmanager.com/gtag/js?id=${ trackingId }`}/>,
-    <script key="gtag-init" dangerouslySetInnerHTML={{ __html: `
-      window.dataLayer = window.dataLayer || [];
-      function gtag() { dataLayer.push(arguments); }
-      gtag('js', new Date());
-      gtag('config', ${ JSON.stringify(trackingId) }, { send_page_view: false });
-    ` }}/>,
+    <link rel="preconnect" href="https://www.google-analytics.com"/>,
+    <link rel="dns-prefetch" href="https://www.google-analytics.com"/>,
+    // See https://developers.google.com/analytics/devguides/collection/analyticsjs#alternative_async_tracking_snippet
+    <script dangerouslySetInnerHTML={{ __html: `
+      window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+      ga('create', '${trackingId}', 'auto');
+      ga('send', 'pageview');
+    `}}/>,
+    <script async src='https://www.google-analytics.com/analytics.js'/>,
   ]);
 };


### PR DESCRIPTION
- [x] GA 스니펫 변경

![image](https://user-images.githubusercontent.com/9696352/66042977-e007c880-e558-11e9-911f-cd9602209efb.png)

Tag Manager 초기화 방식은 우선순위도 높고 GA 외 여러 네트워크 연결들(구글, 구글 마케팅 플랫폼 등)을 만드는데  Tag Manager 없이 GA 만 사용하고 있기에 불필요한 병목이라고 판단했습니다.

[공식 개발자 문서](https://developers.google.com/analytics/devguides/collection/analyticsjs)에 나오는 스니펫 중에 심플한 버전을 적용했습니다. (긴 버전은 async 로딩이 안되는 IE9 이하 브라우저를 위한 추가 코드가 있다고 합니다.)

- [x] preconnect, dns-prefetch 로 리소스 연결 정보 추가
- [x] 정식 버전 릴리즈