### PR TITLE
@devsisters/gatsby-source-site-navigation v1.0.23 publish (Add supportedLangs)

### DIFF
--- a/packages/gatsby-source-site-navigation/package.json
+++ b/packages/gatsby-source-site-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devsisters/gatsby-source-site-navigation",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "main": "index.js",
   "scripts": {
     "develop": "babel src --extensions .ts --out-dir . --watch --copy-files",

--- a/packages/gatsby-source-site-navigation/src/lib.ts
+++ b/packages/gatsby-source-site-navigation/src/lib.ts
@@ -1,13 +1,13 @@
 import type { ThemeOptions } from './types';
 
 export function normalizeLanguage(lang: string) {
-  const supportedLangs = ['en', 'ja', 'ko', 'th', 'zh-Hant', 'zh-Hans'] as const;
+  const supportedLangs = ['en', 'ja', 'ko', 'th', 'zh-Hant', 'zh-Hans', 'de', 'fr'] as const;
   type SupportedLanguage = typeof supportedLangs[number];
 
   const normalized = lang
     .replace(/.*(tw).*/i, 'zh-Hant')
     .replace(/.*(cn).*/i, 'zh-Hans')
-    .replace(/.*(en|ja|ko|th|zh-Hant|zh-Hans).*/i, '$1') as SupportedLanguage;
+    .replace(/.*(en|ja|ko|th|zh-Hant|zh-Hans|de|fr).*/i, '$1') as SupportedLanguage;
 
   if (!supportedLangs.includes(normalized)) {
     throw new Error(`language: ${lang} is not supported`);


### PR DESCRIPTION
prismic 지원 언어에 de, fr을 추가하면서 기존 패키지의 지원언어에도 de, fr을 추가하였습니다